### PR TITLE
Replace find-edit-save() pattern, fix wrong password bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.7] - 2018-12-22
+
+### Changed
+
+- Replaced all findByid-edit-save() logic on the models with findByIdAndUpdate().
+  This cleans up the code and fixes another bug that hashes the user's password everytime you do User.find execute some logic,
+  edit some data and then user.save() for example, because of the User.pre('save') middleware on the user's model which is
+  used to hash the user's password before saving the user in the database.
+
 ## [1.3.6] - 2018-12-21
 
 ### Added

--- a/backend/handlers/boardList.js
+++ b/backend/handlers/boardList.js
@@ -76,7 +76,7 @@ const deleteListHandler = (req, res) => {
             // all values(lists) that equal listId.
             // the list we want to remove will so it will
             // match with listId
-            { $pull: { boardList: listId } },
+            { $pull: { boardLists: listId } },
             { useFindAndModify: false }
           )
             .then(() => {

--- a/backend/handlers/pomodoro.js
+++ b/backend/handlers/pomodoro.js
@@ -19,15 +19,17 @@ const newPomodoro = (req, res) => {
   // create a new pomodoro for the user
   Pomodoro.create({ userId })
     .then(newPomodoro => {
-      // get the logged in user to save the pomodoro to his account
-      User.findById(userId)
-        .then(user => {
-          // push it in the boardlist field
-          user.pomodoros.push(newPomodoro);
-          // save updated user
-          user.save();
+      // get the logged in user
+      User.findByIdAndUpdate(
+        userId,
+        // push the new pomodoro in the array of
+        // pomodoros in the user's account
+        { $push: { pomodoros: newPomodoro } },
+        { useFindAndModify: false }
+      )
+        .then(() => {
           //  send back the new pomodoro
-          res.json(newPomodoro);
+          res.json({ newPomodoro });
         })
         .catch(error => res.handleError(error));
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-platform",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-platform",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "A productivity platform to help you be more focused, productive and manage your time better.",
   "keywords": [
     "productivity",


### PR DESCRIPTION
Replaced all findByid-edit-save() logic on the models with findByIdAndUpdate().
This cleans up the code and fixes another bug that hashes the user's password everytime you do User.find execute some logic, edit some data and then user.save() for example, because of the User.pre('save') middleware on the user's model which is used to hash the user's password before saving the user in the database.