### PR TITLE
1.6.6: Fix page titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.6.5] - 2019-11-17
+## [1.6.6] - 2019-11-17
 
 ### Changed
 
 - Add document titles to each page
 - Fix bug of not closing modal after deleting a board.
+- Updated to correct version
+
+## [1.6.5] - 2019-11-13
+
+### Added
+
+- Screenshots of the project in README
+
+### Changed
+
+- Fixed card moving bug
+- Fixed button type bug in edit form
+- Fixed list title changing bug
 
 ## [1.6.4] - 2019-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.5] - 2019-11-17
+
+### Changed
+
+- Add document titles to each page
+- Fix bug of not closing modal after deleting a board.
+
 ## [1.6.4] - 2019-11-12
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-platform",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-platform",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-platform",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "A productivity platform to help you be more focused, productive and manage your time better.",
   "keywords": [
     "productivity",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-platform",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "A productivity platform to help you be more focused, productive and manage your time better.",
   "keywords": [
     "productivity",

--- a/webclient/public/index.html
+++ b/webclient/public/index.html
@@ -22,7 +22,11 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Prodapp | Productivity platform</title>
+    <meta
+      name="description"
+      content="Unleash your productivity and see your strengths and weaknesses."
+    />
   </head>
 
   <body>

--- a/webclient/src/components/UI/Board/EditBoard/EditBoard.js
+++ b/webclient/src/components/UI/Board/EditBoard/EditBoard.js
@@ -19,9 +19,8 @@ class EditBoard extends Component {
   };
 
   onDelete = () => {
-    // this.props.closeModal();
-    // wait for the modal to close before executing the delete function
     this.props.deleteBoard(this.state.boardId);
+    this.props.closeModal();
   };
 
   render() {

--- a/webclient/src/containers/Boards/Board.js
+++ b/webclient/src/containers/Boards/Board.js
@@ -25,6 +25,8 @@ class Board extends PureComponent {
     ) {
       return <Loader />;
     }
+    document.title = this.props.board.title + " | Productivity Platform";
+
     return (
       <Fragment>
         <div className="Board scrollbar-horizontal">
@@ -86,10 +88,5 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export default DragDropContext(HTML5Backend)(
-  withRouter(
-    connect(
-      mapStateToProps,
-      mapDispatchToProps
-    )(Board)
-  )
+  withRouter(connect(mapStateToProps, mapDispatchToProps)(Board))
 );

--- a/webclient/src/containers/Boards/Boards.js
+++ b/webclient/src/containers/Boards/Boards.js
@@ -97,6 +97,9 @@ class Boards extends Component {
     if (this.state.boards === null) {
       return <Loader />;
     }
+
+    document.title = "Boards | Productivity Platform";
+
     return (
       <div className="Container--Wide Boards scrollbar-horizontal">
         {/* render list */}
@@ -111,9 +114,7 @@ class Boards extends Component {
             />
           ))}
           <button
-            className={`${
-              boardPreviewClasses["Board-Link"]
-            } Board-Preview--Button`}
+            className={`${boardPreviewClasses["Board-Link"]} Board-Preview--Button`}
             onClick={() =>
               this.setState({ showNewBoard: !this.state.showNewBoard })
             }

--- a/webclient/src/containers/LandingPage/LandingPage.js
+++ b/webclient/src/containers/LandingPage/LandingPage.js
@@ -102,6 +102,8 @@ class LandingPage extends Component {
     this.setState(() => ({ showForms: !this.state.showForms }));
 
   render() {
+    document.title = "Prodapp | Productivity Platform";
+
     return (
       <div className="Landing-Page">
         <AuthForms
@@ -132,7 +134,4 @@ const mapDispatchToProps = dispatch => ({
   onAuthSuccess: (token, user) => dispatch(actions.authSuccess(token, user))
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(LandingPage);
+export default connect(mapStateToProps, mapDispatchToProps)(LandingPage);

--- a/webclient/src/containers/Pomodoro/Pomodoro.js
+++ b/webclient/src/containers/Pomodoro/Pomodoro.js
@@ -28,6 +28,7 @@ class Pomodoro extends Component {
 
   componentDidMount() {
     window.addEventListener("focus", this.props.updateTimer);
+    document.title = "Pomodoro | Productivity Platform";
   }
 
   render() {
@@ -98,8 +99,5 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export default withRouter(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(Pomodoro)
+  connect(mapStateToProps, mapDispatchToProps)(Pomodoro)
 );

--- a/webclient/src/containers/Store/Store.js
+++ b/webclient/src/containers/Store/Store.js
@@ -7,6 +7,7 @@ import "./Store.scss";
 
 class Store extends Component {
   render() {
+    document.title = "Store | Productivity Platform";
     const extensions = Object.keys(extensionMap);
     return (
       <div className="Store">
@@ -36,7 +37,4 @@ const mapDispatchToProps = dispatch => ({
     dispatch(actions.removeExtension(extensionName))
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Store);
+export default connect(mapStateToProps, mapDispatchToProps)(Store);


### PR DESCRIPTION
## [1.6.6] - 2019-11-17

### Changed

- Add document titles to each page
- Fix bug of not closing modal after deleting a board.
- Updated to correct version
